### PR TITLE
Fix broken download link and update archive extraction command to unzip zip files.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ mkdir -p ~/.local/lib
 mkdir -p ~/.local/share/pixmaps
 mkdir -p ~/.local/lib/OpenUtau
 echo "Downloading OpenUtau..."
-wget -q https://github.com/stakira/OpenUtau/releases/latest/download/OpenUtau-linux-x64.tar.gz -O /tmp/ou.tar.gz --show-progress 
+wget -q https://github.com/stakira/OpenUtau/releases/download/0.1.565/OpenUtau-linux-x64.zip -O /tmp/ou.tar.gz --show-progress 
 echo "Installing..."
 tar xvf /tmp/ou.tar.gz -C ~/.local/lib/OpenUtau
 echo "Retrieving icon..."

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@ mkdir -p ~/.local/lib/OpenUtau
 echo "Downloading OpenUtau..."
 wget -q https://github.com/stakira/OpenUtau/releases/download/0.1.565/OpenUtau-linux-x64.zip -O /tmp/ou.tar.gz --show-progress 
 echo "Installing..."
-tar xvf /tmp/ou.tar.gz -C ~/.local/lib/OpenUtau
+#tar xvf /tmp/ou.tar.gz -C ~/.local/lib/OpenUtau
+unzip /tmp/ou.tar.gz -d ~/.local/lib/OpenUtau
 echo "Retrieving icon..."
 wget -q https://raw.githubusercontent.com/stakira/OpenUtau/master/Logo/openutau.svg -O ~/.local/share/pixmaps/openutau.svg --show-progress
 echo "Marking executable..."


### PR DESCRIPTION
This commit fixes the broken download link and the command to extract archives has been changed to unzip zip files as the there is no longer a tar.gz available from the OpenUTAU repository.